### PR TITLE
Add missing "Bearer" to Authorization header

### DIFF
--- a/FindMySync/Synchronizer.swift
+++ b/FindMySync/Synchronizer.swift
@@ -200,8 +200,12 @@ findmy_\(id.replacingOccurrences(of: "-", with: "")):
     
     func updateEntity(id: String, latitude: NSNumber, longitude: NSNumber, accuracy: NSNumber, battery: NSNumber) {
         let url: String = UserDefaults.standard.string(forKey: "endpoint_url")!
-        let auth: String = UserDefaults.standard.string(forKey: "endpoint_auth")!
+        var auth: String = UserDefaults.standard.string(forKey: "endpoint_auth")!
         
+        if !auth.hasPrefix("Bearer") {
+            auth = "Bearer " + auth
+        }
+
         
         let sessionConfig = URLSessionConfiguration.default
         let session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: nil)


### PR DESCRIPTION
While testing around with this repo and entering my long-lived access token, i noticed i kept getting HTTP 401. This was because I entered my access token without the "Bearer" prefix, which caused an invalid authorization request on home assistant. I added a simple check to add the Bearer prefix before sending requests